### PR TITLE
Add support for VPCs by adding the subnetid parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ AWS EC2 computer management for regular folks...
 
 ## Installation
 
+Original:
+
+~~`$ pip install git+https://github.com/fastai/fastec2.git`~~
+
+To install from the current fork:
+
 ```bash
-$ pip install git+https://github.com/fastai/fastec2.git
+$ pip install git+https://github.com/mattmoehr/fastec2.git
 ```
 
 To add tab completion for your shell (replace *bash* with *fish* if you use the fish shell, although note as at Feb-2019 there are reports fish completions may be broken in the Google Fire library that this relies on):


### PR DESCRIPTION
You can now specify `--subnetid` on the `launch` and `get_launch` commands. This will start the instance in the subnet you specify, and by extension the VPC containing that subnet. If you do not specify a subnet, one will be chosen for you. (The default is to pick the first subnet from the VPC implied by `--secgroupname`. Note: I am not able to test this with the `default` security group as described in the original blog post about fastec2.)

